### PR TITLE
Adds S3 registration

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -1,0 +1,66 @@
+# nocov start
+.onLoad <- function(libname, pkgname) {
+  # This package has specific methods for the `tunable` generic. That generic
+  # is defined in the `tune` package. As of R 4.0, we need to register them.
+  s3_register("tune::tunable", "step_dwt")
+}
+
+s3_register <- function(generic, class, method = NULL) {
+  stopifnot(is.character(generic), length(generic) == 1)
+  stopifnot(is.character(class), length(class) == 1)
+
+  pieces <- strsplit(generic, "::")[[1]]
+  stopifnot(length(pieces) == 2)
+  package <- pieces[[1]]
+  generic <- pieces[[2]]
+
+  caller <- parent.frame()
+
+  get_method_env <- function() {
+    top <- topenv(caller)
+    if (isNamespace(top)) {
+      asNamespace(environmentName(top))
+    } else {
+      caller
+    }
+  }
+  get_method <- function(method, env) {
+    if (is.null(method)) {
+      get(paste0(generic, ".", class), envir = get_method_env())
+    } else {
+      method
+    }
+  }
+
+  method_fn <- get_method(method)
+  stopifnot(is.function(method_fn))
+
+  # Always register hook in case package is later unloaded & reloaded
+  setHook(
+    packageEvent(package, "onLoad"),
+    function(...) {
+      ns <- asNamespace(package)
+
+      # Refresh the method, it might have been updated by `devtools::load_all()`
+      method_fn <- get_method(method)
+
+      registerS3method(generic, class, method_fn, envir = ns)
+    }
+  )
+
+  # Avoid registration failures during loading (pkgload or regular)
+  if (!isNamespaceLoaded(package)) {
+    return(invisible())
+  }
+
+  envir <- asNamespace(package)
+
+  # Only register if generic can be accessed
+  if (exists(generic, envir)) {
+    registerS3method(generic, class, method_fn, envir = envir)
+  }
+
+  invisible()
+}
+
+# nocov end


### PR DESCRIPTION
Makes sure that the `tunable()` method for the step is seen during method dispatch on R >= 4.0. That version had the change that 

> S3 method lookup now by default skips the elements of the search path between the global and base environments.

Since your package is defining a method for a generic that lives in the `recipes` package, this extra bit of code is needed. 

``` r
library(stepdwt)
#> Loading required package: recipes
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
library(tune)

rec <- recipe( ~ ., data = USArrests)
dwt_trans <- rec %>%
  step_center(all_numeric()) %>%
  step_scale(all_numeric()) %>%
  step_dwt(all_numeric(), filter = tune())

tunable(dwt_trans)
#> # A tibble: 1 x 5
#>   name   call_info        source component component_id
#>   <chr>  <list>           <chr>  <chr>     <chr>       
#> 1 filter <named list [2]> recipe step_dwt  dwt_XOaCE
```

<sup>Created on 2020-09-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>